### PR TITLE
Added support for new lines in RobotSpeech messages, allowing two lin…

### DIFF
--- a/src/app/plugins/robot-speech/robot-speech.component.css
+++ b/src/app/plugins/robot-speech/robot-speech.component.css
@@ -12,14 +12,16 @@
   overflow: auto;
 }
 
-.message-text-container{
+.message-text-container {
   margin-left: 5px;
   margin-right: 5px;
   margin-bottom: 5px;
-  max-width:100%;
-  box-sizing:border-box;
+  box-sizing: border-box;
   padding: 10px 15px;
   border-radius: 10px;
+  align-self: flex-end;
+  max-width: 15em;
+  overflow-wrap: anywhere;
 }
 
 .input-section{

--- a/src/app/plugins/robot-speech/robot-speech.component.html
+++ b/src/app/plugins/robot-speech/robot-speech.component.html
@@ -1,12 +1,20 @@
 <div class="widget-container">
   <div #scrollContainer class="messages-container">
-    <div class="message-text-container" *ngFor="let message of messages" [ngStyle]="{'background-color':messageColors[message.status]}">
-      {{message.text}}
+    <div  *ngFor="let message of messages" style="width: 100%; display:contents">
+     <div class="message-text-container" [ngStyle]="{'background-color': messageColors[message.status]}">
+        {{message.text}}
+      </div>
     </div >
   </div>
   <div class="input-section">
-    <mat-form-field subscriptSizing="dynamic" appearance="outline" style="flex:1;background-color: white">
-      <input matInput #messageInput [(ngModel)]="newMessage" (keydown.enter)="onEnterPress()" placeholder="Type something..."  >
+        <mat-form-field subscriptSizing="dynamic" appearance="outline" style="flex:1">
+      <textarea matInput
+            cdkTextareaAutosize
+            #autosize="cdkTextareaAutosize"
+            cdkAutosizeMinRows="1"
+            cdkAutosizeMaxRows="2"
+            [(ngModel)]="newMessage" (keydown.enter)="onEnterPress(); false" placeholder="Type something..."></textarea>
+
     </mat-form-field>
     <button mat-button style="height:100%;background-color: rgb(119,161,215)" (click)="sendMessage()" [disabled]="inputDisabled">
       <mat-icon>send</mat-icon>

--- a/src/app/plugins/robot-speech/robot-speech.component.ts
+++ b/src/app/plugins/robot-speech/robot-speech.component.ts
@@ -28,7 +28,7 @@ export class RobotSpeechComponent extends WidgetBaseComponent {
 
   onEnterPress() {
     if (this.inputDisabled) {
-    return; // Do nothing if input is disabled
+      return; // Do nothing if input is disabled
     }
     this.sendMessage()
   }


### PR DESCRIPTION
## Changes Made

1. **Added support for line breaks in RobotSpeech messages**  
   Previously, long messages would overflow and be hidden behind the speech box. This update ensures messages can properly wrap to the next line.

2. **Enhanced input field to support two visible lines**  
   The input now expands to show up to two lines for longer messages. This replaces the single-line input with horizontal scrolling, improving usability and readability.